### PR TITLE
Add .DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 CMakeSettings.json
 .idea/
 
+# OS metadata
+.DS_Store
+
 # Other
 Debug/
 lib/


### PR DESCRIPTION
Adds `.DS_Store` (macOS creates them automatically) to gitignore.